### PR TITLE
Moved sharebar css from win-app to sharebar...

### DIFF
--- a/example.css
+++ b/example.css
@@ -9,27 +9,36 @@
   display: table;
 }
 
-.header__home {
+.header__home,
+.header__hamburger {
   width: 49px;
   background: var(--color-economist);
   vertical-align: middle;
   text-align: center;
 }
 
-.header__home use {
+.header__home use,
+.header__hamburger use {
   fill: white;
+}
+
+.header__home {
+  border-right: 1px solid var(--color-thimphu);
+  border-left: 1px solid var(--color-thimphu);
 }
 
 .header__spacer {
   background: var(--color-beijing);
-  width: calc(100% - (49px*2));
+  width: 100%;
 }
 
 .header__share {
   width: 49px;
+  min-width: 49px;
 }
 
 .header__home,
+.header__hamburger,
 .header__spacer,
 .header__share {
   display: table-cell;

--- a/example.es6
+++ b/example.es6
@@ -4,12 +4,15 @@ import Icon from '@economist/component-icon';
 
 export default (
   <div className="header">
-    <div className="header__home">
-      <Icon size="49px" icon="home" />
-    </div>
     <div className="header__spacer" />
     <div className="header__share">
       <WinSharebar />
+    </div>
+    <div className="header__home">
+      <Icon size="49px" icon="home" />
+    </div>
+    <div className="header__hamburger">
+      <Icon size="49px" icon="hamburger" />
     </div>
   </div>
 );

--- a/index.css
+++ b/index.css
@@ -10,14 +10,30 @@
 .win-sharebar .toggle-display__content {
   position: absolute;
   top: 49px;
-  right: 0;
+  right: -99px;
 }
 
 .win-sharebar [data-display="open"] .toggle-display__content {
   border-top: 1px solid var(--color-thimphu);
 }
 
+.win-sharebar .toggle-display[data-display="open"] .toggle-display__button {
+  height: 52px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 11;
+}
+
+.win-sharebar .toggle-display[data-display="open"] .toggle-display__content {
+  border-top: solid 1px var(--color-thimphu);
+}
+
 @media screen and (min-width: 650px) {
+  .win-sharebar .share__icon--whatsapp {
+    display: none;
+  }
+
   .win-sharebar .toggle-display__content {
     top: 0;
     right: 50px;
@@ -35,5 +51,10 @@
     border: 0 none;
     border-left: 1px solid var(--color-thimphu);
     border-right: 1px solid var(--color-thimphu);
+  }
+
+  .win-sharebar .toggle-display[data-display="open"] .toggle-display__button {
+    position: static;
+    height: 49px;
   }
 }


### PR DESCRIPTION
Updated example to better reflect how it's used in the win app and added hiding the whatsapp icon above 650.